### PR TITLE
Fix a bug that leads to "ValueError: axes don't match array" in dataset_tool.py

### DIFF
--- a/dataset_tool.py
+++ b/dataset_tool.py
@@ -669,7 +669,9 @@ def create_from_images(tfrecord_dir, image_dir, shuffle):
     with TFRecordExporter(tfrecord_dir, len(image_filenames)) as tfr:
         order = tfr.choose_shuffled_order() if shuffle else np.arange(len(image_filenames))
         for idx in range(order.size):
-            img = np.asarray(PIL.Image.open(image_filenames[order[idx]]))
+            pil_img = PIL.Image.open(image_filenames[order[idx]])
+            pil_img = pil_img.convert("RGB")
+            img = np.asarray(pil_img)
             if channels == 1:
                 img = img[np.newaxis, :, :] # HW => CHW
             else:


### PR DESCRIPTION
This is a patch to the [Issue #110](https://github.com/NVlabs/stylegan2-ada/issues/110)

Here's a fix for `dataset_tool.py` that fixes `ValueError: axes don't match array, images will work one run and not work the next` error.

My debugging of the issue was as follows: 
- I first thought that maybe some of the images I scraped were grayscale. To solve this I used `imagemagick` and tried to run `magick identify *.jpg `to search for greyscale images to purge from the dataset but the issue still persisted in my case. 
- I tried to mass-edit the colorspace of the images and resolution. This still hasn't fixed the error which I was randomly getting on some of the images.
- I still can't debug the exact origin of the issue such as a specific colorspace causing `dataset_tool.py` to crash.

I propose to use PIL to convert the image to RGB in any case. It should be able to work fine if the images are not `sRGB`, including the case when they are grayscale. It will most likely slows down the dataset preprocessing step a little bit (I haven't run any benchmarks). However, it is convenient if the training data is coming from varied sources, which I believe is the case for my users. 